### PR TITLE
- hookSetObject:forKey:cost: String Format Error

### DIFF
--- a/NSObjectSafe/NSObjectSafe.m
+++ b/NSObjectSafe/NSObjectSafe.m
@@ -774,7 +774,7 @@ void SFLog(const char* file, const char* func, int line, NSString* fmt, ...)
     if (obj && key) {
         [self hookSetObject:obj forKey:key cost:g];
     }else {
-        SFAssert(NO, @"NSCache invalid args hookSetObject:[%@] forKey:[%@] cost:[%@]", obj, key, g);
+        SFAssert(NO, @"NSCache invalid args hookSetObject:[%@] forKey:[%@] cost:[%@]", obj, key, @(g));
     }
 }
 @end


### PR DESCRIPTION
`g` is not an object.
you should make it a `NSNumber`